### PR TITLE
Write optimized imports

### DIFF
--- a/build_runner/bin/import_optimizer.dart
+++ b/build_runner/bin/import_optimizer.dart
@@ -26,9 +26,9 @@ Future<Null> main(List<String> args) async {
   if (args.isEmpty) {
 //    print(
 //        'Demo run: dart ./bin/import_optimizer.dart "build_runner|lib/src/entrypoint/options.dart" "build_runner|lib/src/asset_graph/graph.dart"');
-   print('dart ./bin/import_optimizer.dart "build_runner"');
+   print('dart ./bin/import_optimizer.dart "build_runner" [apply]');
   }
-  new ImportOptimizer().optimizePackage(args[0]);
+  new ImportOptimizer().optimizePackage(args[0], applyImports: args.length > 1 && args[1].toLowerCase() == 'apply');
 //  new ImportOptimizer().optimizeFiles(args);
 //  new ImportOptimizer().optimizeFiles(['build_runner|lib/src/server/asset_graph_handler.dart']);
 //  ArgResults parsedArgs;

--- a/build_runner/lib/src/import_optimizer/import_optimizer.dart
+++ b/build_runner/lib/src/import_optimizer/import_optimizer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_resolvers/build_resolvers.dart';
@@ -68,8 +69,11 @@ class ImportOptimizer{
          print(output);
 
          if (_applyImports) {
-           _replaceImportsInFile(inputId.path, output, lib.unit.directives.beginToken.charOffset,
-               lib.unit.directives.endToken.charOffset);
+           final firstImport = lib.unit.directives.firstWhere((dir) => dir.keyword.keyword == Keyword.IMPORT);
+           final lastImport = lib.unit.directives.lastWhere((dir) => dir.keyword.keyword == Keyword.IMPORT);
+
+           _replaceImportsInFile(inputId.path, output, firstImport.beginToken.charOffset,
+               lastImport.endToken.charOffset);
          }
        }
      } catch(e,st){


### PR DESCRIPTION
Ability to apply optimized imports by specific command line parameter.
at the moment we have several well known issues. Just to be clear. 
1. conditional imports not supported (will be imported onlu first)
2. as not supported
3. suggests deprecated imports
4. don't see exports from /impl folder.... (???)
5. Use both equivalent imports 
    import 'package:wrike_dal/injector.dart';
    import 'package:wrike_dal_core/injector.dart';
  in case WrikeInjectorModules imported
6. ~~part of and libreries - are removed during writing file...~~
7. When we already have import import 'package:angular/angular.dart';
   optimizer suggests 
    import 'package:angular/angular.dart';
    import 'package:angular/core.dart';
    import 'package:angular/di.dart';

    also
     have  import 'package:wrike_components/component/tooltip_v2/tooltip_v2.dart';
     sugested
        import 'package:wrike_components/component/tooltip_v2/models/close_tooltip_event.dart';
        import 'package:wrike_components/component/tooltip_v2/models/close_tooltip_trigger_type.dart';
        import 'package:wrike_components/component/tooltip_v2/tooltip_v2.dart';
