### PR TITLE
Improve import optimizer

### DIFF
--- a/build_runner/lib/src/import_optimizer/import_optimizer.dart
+++ b/build_runner/lib/src/import_optimizer/import_optimizer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
-
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
@@ -20,6 +21,7 @@ class ImportOptimizer{
   static final log.Logger _log = new log.Logger('ImportOptimizer');
   static final _resolvers = new AnalyzerResolvers();
   static final packageGraph = new PackageGraph.forThisPackage();
+  
   final io = new IOEnvironment(packageGraph, true);
   final _resourceManager = new ResourceManager();
   final WorkResult _workResult;
@@ -31,7 +33,6 @@ class ImportOptimizer{
   optimizePackage(String package) async {
     _log.info("Optimization package: '$package'");
     var assets = (await io.reader.findAssets(new Glob('lib/**.dart'), package: package).toList()).map((item)=>item.toString())
-        //.where((item)=>!item.contains('/demo') && !item.contains('/example'))
         .toList();
     optimizeFiles(assets);
   }
@@ -63,10 +64,10 @@ class ImportOptimizer{
      Resolver resolver = await _resolvers.get(buildStep);
      try {
        var lib = await buildStep.inputLibrary;
-       var vis = new GatherUsedImportedElementsVisitor(lib);
-       lib.unit.accept(vis);
-       var libraries = _convertElementToLibrary(vis.usedElements);
-       var optLibraries = await _optimizationImport(inputId, libraries, resolver);
+       var usedImportedElementsVisitor = new UsedImportedElementsVisitor(lib);
+       lib.unit.accept(usedImportedElementsVisitor);
+       var usedElements = _getUsedElements(usedImportedElementsVisitor.usedElements);
+       var optLibraries = await _getLibrariesForElemets(inputId, usedElements, resolver);
        var output = _generateImportText(inputId, lib, optLibraries);
        if (output.isNotEmpty) {
          final stat = _workResult.statistics[inputId];
@@ -125,10 +126,11 @@ class ImportOptimizer{
      return imports.length;
    }
 
-   Future<Iterable<LibraryElement>> _optimizationImport(AssetId inputId, Iterable<LibraryElement> libraries, Resolver resolver) async {
-     var outputImports = new Set<LibraryElement>();
-     for (var library in libraries ){
-       var source = library.source;
+  Future<Iterable<LibraryElement>> _getLibrariesForElemets(AssetId inputId, Iterable<Element> elements, Resolver resolver) async {
+    var libraries = new Set<LibraryElement>();
+     for (var element in elements ){
+       var source = element.source;
+       var library = element.library;
        if (source is AssetBasedSource){
          var assetId = source.assetId;
          var optLibrary = library;
@@ -136,17 +138,50 @@ class ImportOptimizer{
            if (settings.allowSrcImport){
              optLibrary = library;
            } else {
-             optLibrary = await _getOptLibraryImport(library, resolver);
+             optLibrary = await _getOptimumLibraryWhichExportsElement(element, resolver);
            }
          }
-         outputImports.add(optLibrary);
+         libraries.add(optLibrary);
        } else {
-         outputImports.add(library);
+         libraries.add(library);
        }
-
      }
-     return outputImports;
-   }
+     return libraries;
+  }
+
+  Future<LibraryElement> _getOptimumLibraryWhichExportsElement(Element element, Resolver resolverI) async {
+    var source = element.library.source as AssetBasedSource;
+    var result = element.library;
+    var resultImportsCount = 99999999;
+    var assets = await io.reader.findAssets(new Glob('lib/**.dart'), package: source.assetId.package).toList();
+    for (var assetId in assets) {
+      if (!assetId.path.contains('/src/')) {
+        
+        try {
+          var resolver = resolverI;
+          if (!await resolver.isLibrary(assetId)){
+            resolver = await _resolvers.get(new BuildStepImpl(assetId, [], _reader, null, assetId.package, _resolvers, _resourceManager));
+          }
+          if (!await resolver.isLibrary(assetId)){
+            //skip
+            continue;
+          }
+          var library = await resolver.libraryFor(assetId);
+          var count = _getNodeCount(library.exportedLibraries);
+          if (resultImportsCount > count) {
+            if (_isLibraryExportsElement(library, element)) {
+              result = library;
+              resultImportsCount = count;
+            }
+          }
+        }
+        catch (e, s) {
+          _log.fine('Error asset: "$assetId" for "${source.assetId}"', e, s);
+        }
+      }
+    }
+    return result;
+  }
 
   int _getNodeCountAccumulate(Iterable<LibraryElement> libImports) {
     var sum = 0;
@@ -220,77 +255,37 @@ class ImportOptimizer{
       return _DirectivePriority.IMPORT_REL;
   }
 
-
-  Future<LibraryElement> _getOptLibraryImport(LibraryElement library, Resolver resolverI) async {
-    var source = library.source as AssetBasedSource;
-    var result = library;
-    var resultImportsCount = 99999999;
-    var assets = await io.reader.findAssets(new Glob('lib/**.dart'), package: source.assetId.package).toList();
-    for (var assetId in assets) {
-      if (!assetId.path.contains('/src/')) {
-        try {
-          var resolver = resolverI;
-          if (!await resolver.isLibrary(assetId)){
-            resolver = await _resolvers.get(new BuildStepImpl(assetId, [], _reader, null, assetId.package, _resolvers, _resourceManager));
-          }
-          if (!await resolver.isLibrary(assetId)){
-            //skip
-            continue;
-          }
-          var lib = await resolver.libraryFor(assetId);
-          var count = _getNodeCount(lib.exportedLibraries);
-          if (resultImportsCount > count) {
-            if (_deepSearch(lib, source.assetId)) {
-              result = lib;
-              resultImportsCount = count;
-            }
-          }
-        }
-        catch (e, s) {
-          _log.fine('Error asset: "$assetId" for "${source.assetId}"', e, s);
-        }
-      }
-    }
-    return result;
-  }
-
-  bool _deepSearch(LibraryElement lib, AssetId target) {
-    for (var exportLib in lib.exportedLibraries) {
-      var sourceLib = exportLib.source;
-      if ((sourceLib is AssetBasedSource && sourceLib.assetId == target)
-          || _deepSearch(exportLib, target)
-      ) {
-        return true;
-      }
+  bool _isLibraryExportsElement(LibraryElement library, Element elem) {
+    var visitor = new ExportedElementsVisitor(library);
+    library.unit.accept(visitor);
+    if (visitor.elements.any((element) => element.name == elem.name)) {
+      return true;
     }
     return false;
   }
 
-  Iterable<LibraryElement> _convertElementToLibrary(UsedImportedElements usedElements) {
-     var libs = new Set<LibraryElement>();
-     usedElements.prefixMap.values.expand((i)=>i).forEach((element) {
+  Iterable<Element> _getUsedElements(UsedImportedElements usedElements) {
+    var elements = new Set<Element>();
+    usedElements.prefixMap.values.expand((i)=>i).forEach((element) {
        var library = element.library;
        if (library != null &&
            library.isPublic &&
-//           !library.isPrivate &&
-//           !library.isDartCore &&
            !library.source.uri.toString().contains(':_')
        ) {
-         libs.add(library);
+         elements.add(element);
        }
      });
+     
      usedElements.elements.forEach((element) {
        var library = element.library;
        if (library != null &&
            library.isPublic &&
-//           !library.isPrivate &&
-//           !library.isDartCore &&
            !library.source.uri.toString().contains(':_')
        ) {
-         libs.add(library);
+         elements.add(element);
        }
      });
-     return libs;
+     return elements;
   }
 
   void _showReport() {
@@ -400,4 +395,176 @@ class _DirectivePriority {
 
   @override
   String toString() => name;
+}
+
+/**
+ * A visitor that visits ASTs and fills elements which exports current library including reexports from another library
+ */
+class ExportedElementsVisitor extends RecursiveAstVisitor {
+  final LibraryElement library;
+  final Set<Element> elements = new Set<Element>();
+  ExportedElementsVisitor(this.library);
+  @override
+  void visitExportDirective(ExportDirective node) {
+    ExportElement exportElement = node.element;
+    if (exportElement != null) {
+      LibraryElement library = exportElement.exportedLibrary;
+      if (library != null) {
+        // case when export statement use show/hide substatement
+        if (node.combinators.length > 0) {
+          for (Combinator combinator in node.combinators) {
+            if (combinator is HideCombinator) {
+                // TODO cover this case
+            } else {
+              var names = (combinator as ShowCombinator).shownNames;
+              for (var name in names) {
+                elements.add(name.staticElement);
+              }
+            }
+          }
+        } else {
+          // case when exported all elements from library
+          if (library.exportNamespace != null) {
+            for (var element in library.exportNamespace.definedNames.values) {
+              elements.add(element);
+            }
+          }
+        }
+      }
+    }
+    super.visitExportDirective(node);
+  }
+}
+
+/**
+ * A visitor that visits ASTs and fills [UsedImportedElements].
+ */
+class UsedImportedElementsVisitor extends RecursiveAstVisitor {
+  final LibraryElement library;
+  final UsedImportedElements usedElements = new UsedImportedElements();
+
+  UsedImportedElementsVisitor(this.library);
+
+  @override
+  void visitExportDirective(ExportDirective node) {
+    _visitDirective(node);
+  }
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    //if (node!= null && node.element != null && node.element.library == library) {
+      node.implementsClause?.accept(this);
+      node.withClause?.accept(this);
+      node.extendsClause?.accept(this);
+    //}
+    super.visitClassDeclaration(node);
+  }
+  
+  @override
+  void visitImplementsClause(ImplementsClause node) {
+    if (node != null && node.interfaces!= null) {
+      node.interfaces.accept(this);
+      node.interfaces.forEach((interface) {
+          interface.visitChildren(this);
+          if (interface != null && interface.name != null && interface.name.staticElement != null) {            
+            usedElements.elements.add(interface.type.element);
+          } else if (interface != null && interface.type != null && interface.type.element!=null) {
+            usedElements.elements.add(interface.type.element);
+          }
+      });
+    }
+  }
+  
+
+  @override
+  void visitImportDirective(ImportDirective node) {
+    _visitDirective(node);
+  }
+
+  @override
+  void visitLibraryDirective(LibraryDirective node) {
+    _visitDirective(node);
+  }
+
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    _visitIdentifier(node, node.staticElement);
+  }
+
+  /**
+   * If the given [identifier] is prefixed with a [PrefixElement], fill the
+   * corresponding `UsedImportedElements.prefixMap` entry and return `true`.
+   */
+  bool _recordPrefixMap(SimpleIdentifier identifier, Element element) {
+    bool recordIfTargetIsPrefixElement(Expression target) {
+      if (target is SimpleIdentifier && target.staticElement is PrefixElement) {
+        List<Element> prefixedElements = usedElements.prefixMap
+            .putIfAbsent(target.staticElement, () => <Element>[]);
+        prefixedElements.add(element);
+        return true;
+      }
+      return false;
+    }
+
+    AstNode parent = identifier.parent;
+    if (parent is MethodInvocation && parent.methodName == identifier) {
+      return recordIfTargetIsPrefixElement(parent.target);
+    }
+    if (parent is PrefixedIdentifier && parent.identifier == identifier) {
+      return recordIfTargetIsPrefixElement(parent.prefix);
+    }
+    return false;
+  }
+
+  /**
+   * Visit identifiers used by the given [directive].
+   */
+  void _visitDirective(Directive directive) {
+    directive.documentationComment?.accept(this);
+    directive.metadata.accept(this);
+  }
+
+  void _visitIdentifier(SimpleIdentifier identifier, Element element) {
+    if (element == null) {
+      return;
+    }
+    // If the element is multiply defined then call this method recursively for
+    // each of the conflicting elements.
+    if (element is MultiplyDefinedElement) {
+      List<Element> conflictingElements = element.conflictingElements;
+      int length = conflictingElements.length;
+      for (int i = 0; i < length; i++) {
+        Element elt = conflictingElements[i];
+        _visitIdentifier(identifier, elt);
+      }
+      return;
+    }
+
+    // Record `importPrefix.identifier` into 'prefixMap'.
+    if (_recordPrefixMap(identifier, element)) {
+      return;
+    }
+
+    if (element is PrefixElement) {
+      usedElements.prefixMap.putIfAbsent(element, () => <Element>[]);
+      return;
+    } else if (element.enclosingElement is! CompilationUnitElement) {
+      // Identifiers that aren't a prefix element and whose enclosing element
+      // isn't a CompilationUnit are ignored- this covers the case the
+      // identifier is a relative-reference, a reference to an identifier not
+      // imported by this library.
+      return;
+    }
+    // Ignore if an unknown library.
+    LibraryElement containingLibrary = element.library;
+    if (containingLibrary == null) {
+      return;
+    }
+    // Ignore if a local element.
+    if (library == containingLibrary) {
+      return;
+    }
+    // Remember the element.
+    usedElements.elements.add(element);
+  }
 }


### PR DESCRIPTION
### 1
В текущей реализации импорт оптимайзер осуществляет поиск в глубину public library которая экспортит private library.
Это не совсем верно, потому что на самом деле нужно искать public library, которая экспортит сущность из private library;
Разберем на конкретном примере.
ищем оптимальный импорт для сущности onInit котоый находится в 
angular/lib/src/core/metadata/lifecycle_hooks.dart
понимаем что это пакет angular
далее ищем в angular/lib
заходим
angular/lib/di.dart
находим конструкцию
export 'src/core/metadata.dart' show Component, Directive, Input, Output;
в разборе это lib.exportedLibrary
Заходим в 
angular/lib/src/core/metadata.dart
видим
```
export 'metadata/lifecycle_hooks.dart'
    show
        AfterContentInit,
        AfterContentChecked,
        AfterViewInit,
        AfterViewChecked,
        OnChanges,
        OnDestroy,
        OnInit,
        DoCheck;
```
действительно, в итоге angular/lib/di.dart действительно в дереве ссылается на angular/lib/src/core/metadata/lifecycle_hooks.dart,
но не экспортит искомую сущность OnInit.
в итоге для OnInit подставляется импорт angular/lib/di.dart
### 2
Так же игнорируются сущности, используемы в конструкции
```
class A implements B;
```

Этот PR исправляет эти проблемы
